### PR TITLE
Add truncate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $rotation
     ->compress() // Optional, compress the file after rotated. Default false
     ->files(30) // Optional, files are rotated 30 times before being removed. Default 366
     ->minSize(1024) // Optional, are rotated when they grow bigger than 1024 bytes. Default 0
+    ->truncate() // Optional, truncate the original log file in place after creating a copy, instead of moving the old log file.
     ->then(function ($filenameTarget, $filenameRotated) {}) // Optional, to get filename target and original filename
     ->catch(function (RotationFailed $exception) {}) // Optional, to catch a exception in rotating
     ->rotate('file.log');
@@ -46,6 +47,7 @@ $rotation = new Rotation([
     'files' => 1,
     'compress' => true,
     'min-size' => 10,
+    'truncate' => false,
     'then' => function ($filename) {},
     'catch' => function (RotationFailed $exception) {},
 ]);

--- a/tests/Compress/GzTest.php
+++ b/tests/Compress/GzTest.php
@@ -7,7 +7,7 @@ use Cesargb\Log\Test\TestCase;
 
 class GzTest extends TestCase
 {
-    public function test_rotation_processor_with_gz_processor()
+    public function testRotationProcessorWithGzProcessor()
     {
         $rotation = new Rotation();
 
@@ -27,10 +27,10 @@ class GzTest extends TestCase
             $this->assertEquals(self::DIR_WORK.'file.log.1.gz', $fileRotated);
         })->rotate(self::DIR_WORK.'file.log');
 
-        $this->assertStringEqualsFile(self::DIR_WORK.'file.log', '');
+        // $this->assertStringEqualsFile(self::DIR_WORK.'file.log', '');
 
         $this->assertFileExists(self::DIR_WORK.'file.log.1.gz');
 
-        $this->assertEquals($content, implode("", gzfile(self::DIR_WORK.'file.log.1.gz')));
+        $this->assertEquals($content, implode('', gzfile(self::DIR_WORK.'file.log.1.gz')));
     }
 }

--- a/tests/OptionTest.php
+++ b/tests/OptionTest.php
@@ -3,16 +3,16 @@
 namespace Cesargb\Log\Test;
 
 use Cesargb\Log\Rotation;
-use Cesargb\Log\Test\TestCase;
 
 class OptionTest extends TestCase
 {
-    public function test_pass_options()
+    public function testPassOptions()
     {
         $rotation = new Rotation([
             'files' => 1,
             'compress' => true,
             'min-size' => 10,
+            'truncate' => false,
             'then' => function ($filename) {},
             'catch' => function ($error) {},
         ]);
@@ -20,7 +20,7 @@ class OptionTest extends TestCase
         $this->assertNotNull($rotation);
     }
 
-    public function test_catch_exceptio_if_method_is_not_permited()
+    public function testCatchExceptioIfMethodIsNotPermited()
     {
         $this->expectException(\LogicException::class);
 

--- a/tests/Processors/RotativeProcessorTest.php
+++ b/tests/Processors/RotativeProcessorTest.php
@@ -7,7 +7,7 @@ use Cesargb\Log\Test\TestCase;
 
 class RotativeProcessorTest extends TestCase
 {
-    public function test_rotation_processor()
+    public function testRotationProcessor()
     {
         $maxFiles = 5;
 
@@ -20,7 +20,7 @@ class RotativeProcessorTest extends TestCase
             $rotation->rotate(self::DIR_WORK.'file.log');
         }
 
-        $this->assertStringEqualsFile(self::DIR_WORK.'file.log', '');
+        // $this->assertStringEqualsFile(self::DIR_WORK.'file.log', '');
 
         foreach (range(1, $maxFiles) as $n) {
             $this->assertFileExists(self::DIR_WORK.'file.log.'.$n);
@@ -29,7 +29,7 @@ class RotativeProcessorTest extends TestCase
         $this->assertFalse(is_file(self::DIR_WORK.'file.log.'.($maxFiles + 1)));
     }
 
-    public function test_rotation_processor_with_gz_processor()
+    public function testRotationProcessorWithGzProcessor()
     {
         $maxFiles = 5;
 
@@ -43,7 +43,7 @@ class RotativeProcessorTest extends TestCase
             $rotation->rotate(self::DIR_WORK.'file.log');
         }
 
-        $this->assertStringEqualsFile(self::DIR_WORK.'file.log', '');
+        // $this->assertStringEqualsFile(self::DIR_WORK.'file.log', '');
 
         foreach (range(1, $maxFiles) as $n) {
             $this->assertFileExists(self::DIR_WORK."file.log.{$n}.gz");

--- a/tests/RotationTest.php
+++ b/tests/RotationTest.php
@@ -28,15 +28,13 @@ class RotationTest extends TestCase
         $this->assertFileDoesNotExist(self::DIR_WORK.'file.log.1');
     }
 
-    public function testOptionNocompress()
+    public function testRotationDefault()
     {
         file_put_contents(self::DIR_WORK.'file.log', microtime(true));
 
         $rotation = new Rotation();
 
         $rotation->rotate(self::DIR_WORK.'file.log');
-
-        $this->assertStringEqualsFile(self::DIR_WORK.'file.log', '');
 
         $this->assertFileExists(self::DIR_WORK.'file.log.1');
     }
@@ -103,5 +101,31 @@ class RotationTest extends TestCase
         $rotation->minSize(1)->rotate(self::DIR_WORK.'file.log');
 
         $this->assertFileExists(self::DIR_WORK.'file.log.1');
+    }
+
+    public function testRotationTruncate()
+    {
+        file_put_contents(self::DIR_WORK.'file.log', microtime(true));
+
+        $rotation = new Rotation();
+
+        $rotation->truncate()->rotate(self::DIR_WORK.'file.log');
+
+        $this->assertStringEqualsFile(self::DIR_WORK.'file.log', '');
+
+        $this->assertFileExists(self::DIR_WORK.'file.log.1');
+    }
+
+    public function testOptionTruncateAndCompress()
+    {
+        file_put_contents(self::DIR_WORK.'file.log', microtime(true));
+
+        $rotation = new Rotation();
+
+        $rotation->compress()->truncate()->rotate(self::DIR_WORK.'file.log');
+
+        $this->assertStringEqualsFile(self::DIR_WORK.'file.log', '');
+
+        $this->assertFileExists(self::DIR_WORK.'file.log.1.gz');
     }
 }


### PR DESCRIPTION
Truncate the original log file in place after creating a copy, instead of moving the old log file.It can be used when some program cannot be told to close its logfile and thus might continue writing (appending) to the previous log file forever.